### PR TITLE
no title case

### DIFF
--- a/styles/offense.md
+++ b/styles/offense.md
@@ -6,5 +6,6 @@
 - The title may NOT sound like a task order or a suggestion
 - Don't use words like ERROR or BUG, instead explicitly say what kind of error is there
 - Use aggressive tone, to ephasize the problem at hands
+- Don't use Title Case, instead write the title as a normal sentence (don't capitalize words in the middle of it)
 
 {include:_footer.md}

--- a/styles/order.md
+++ b/styles/order.md
@@ -5,5 +5,6 @@
 - The title MUST sound like a task order, starting with a verb
 - Don't use words like ERROR or BUG, instead explicitly say what kind of error is there
 - Use polite tone, to encourange programmers to work with this issue
+- Don't use Title Case, instead write the title as a normal sentence (don't capitalize words in the middle of it)
 
 {include:_footer.md}

--- a/styles/summary.md
+++ b/styles/summary.md
@@ -5,5 +5,6 @@
 - The title must be a summarization of the problem or an ABSTRACT
 - Don't use words like ERROR or BUG, instead explicitly say what kind of error is there
 - Use neutral tone, to make the title sound like a title of a book or a paper
+- Don't use Title Case, instead write the title as a normal sentence (don't capitalize words in the middle of it)
 
 {include:_footer.md}


### PR DESCRIPTION
This may help avoid title case in some cases (it's not stable now).

Here it's title case: https://github.com/objectionary/eo/issues/4126
Here it's not: https://github.com/objectionary/eo/issues/4127

After this PR is merged, we'll have no Title Case always.
