### PR TITLE
feat: block editing

### DIFF
--- a/src/core/pre_checks.py
+++ b/src/core/pre_checks.py
@@ -1,0 +1,19 @@
+def block_user_title_edit(event_data, skip_label, github_client, issue):
+    if not isinstance(event_data, dict):
+        return False
+    if event_data["action"] != "edited":
+        return False
+    if event_data["sender"]["type"] != "User":
+        return False
+
+    previous_title = event_data["changes"]["title"]["from"]
+    if not previous_title:
+        return False
+    if skip_label not in [label["name"] for label in event_data["issue"]["labels"]]:
+        return False
+
+    github_client.add_issue_comment(
+        issue, "This issue has already been processed. Please do not change the title."
+    )
+    issue.edit(title=previous_title)
+    return True

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -35,6 +35,7 @@ class Config:
         self.event_path = os.environ.get("GITHUB_EVENT_PATH")
         self.is_issue_event = self.event_name == "issues"
         self.issue_number = None
+        self.event_data = None
 
         # If it's an issue event, get the issue number
         if self.is_issue_event and self.event_path and os.path.exists(self.event_path):
@@ -43,6 +44,7 @@ class Config:
 
                 with open(self.event_path) as f:
                     event_data = json.load(f)
+                    self.event_data = event_data
                     if "issue" in event_data and "number" in event_data["issue"]:
                         self.issue_number = event_data["issue"]["number"]
             except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import sys
 from core.github_client import GitHubClient
 from core.issue_service import IssueProcessor
 from core.llm import create_ai_client
+from core.pre_checks import block_user_title_edit
 from core.settings import Config
 from core.verbose import set_verbose
 
@@ -13,6 +14,10 @@ def open_issue_event(config, repo_obj, ai_client, github_client):
     print(f"Processing single issue #{config.issue_number} from event trigger")
     try:
         issue = repo_obj.get_issue(config.issue_number)
+
+        if block_user_title_edit(config.event_data, config.skip_label, github_client, issue):
+            return []
+
         issue_processor = IssueProcessor(
             ai_client, github_client, config.prompt, config.skip_label, config.required_labels
         )

--- a/tests/test_pre_checks.py
+++ b/tests/test_pre_checks.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.core.pre_checks import block_user_title_edit
+
+
+@pytest.fixture
+def mock_event_data():
+    """Create mock event data for edited issue title."""
+    return {
+        "action": "edited",
+        "sender": {"type": "User"},
+        "changes": {"title": {"from": "Original Title"}},
+        "issue": {"labels": [{"name": "titled"}]},
+    }
+
+
+@pytest.fixture
+def mock_github_client():
+    """Create a mock GitHub client."""
+    client = Mock()
+    client.add_issue_comment = Mock()
+    return client
+
+
+@pytest.fixture
+def mock_issue():
+    """Create a mock GitHub issue."""
+    issue = Mock()
+    issue.edit = Mock()
+    return issue
+
+
+def test_block_user_title_edit_success(mock_event_data, mock_github_client, mock_issue):
+    """Test successful blocking of a user title edit."""
+    result = block_user_title_edit(mock_event_data, "titled", mock_github_client, mock_issue)
+
+    # Assert the function returns True
+    assert result is True
+
+    # Assert comment was added with correct message
+    mock_github_client.add_issue_comment.assert_called_once_with(
+        mock_issue, "This issue has already been processed. Please do not change the title."
+    )
+
+    # Assert title was reverted back to the original
+    mock_issue.edit.assert_called_once_with(title="Original Title")
+
+
+def test_block_user_title_edit_not_edited_action(mock_event_data, mock_github_client, mock_issue):
+    """Test when action is not 'edited'."""
+    mock_event_data["action"] = "created"
+
+    result = block_user_title_edit(mock_event_data, "titled", mock_github_client, mock_issue)
+
+    assert result is False
+    mock_github_client.add_issue_comment.assert_not_called()
+    mock_issue.edit.assert_not_called()
+
+
+def test_block_user_title_edit_not_user(mock_event_data, mock_github_client, mock_issue):
+    """Test when sender is not a User."""
+    mock_event_data["sender"]["type"] = "Bot"
+
+    result = block_user_title_edit(mock_event_data, "titled", mock_github_client, mock_issue)
+
+    assert result is False
+    mock_github_client.add_issue_comment.assert_not_called()
+    mock_issue.edit.assert_not_called()
+
+
+def test_block_user_title_edit_no_previous_title(mock_event_data, mock_github_client, mock_issue):
+    """Test when there is no previous title."""
+    mock_event_data["changes"]["title"]["from"] = ""
+
+    result = block_user_title_edit(mock_event_data, "titled", mock_github_client, mock_issue)
+
+    assert result is False
+    mock_github_client.add_issue_comment.assert_not_called()
+    mock_issue.edit.assert_not_called()
+
+
+def test_block_user_title_edit_no_skip_label(mock_event_data, mock_github_client, mock_issue):
+    """Test when the issue doesn't have the skip label."""
+    mock_event_data["issue"]["labels"] = [{"name": "bug"}]
+
+    result = block_user_title_edit(mock_event_data, "titled", mock_github_client, mock_issue)
+
+    assert result is False
+    mock_github_client.add_issue_comment.assert_not_called()
+    mock_issue.edit.assert_not_called()


### PR DESCRIPTION
If the tool has already changed the title, the user should not be able to edit it again.